### PR TITLE
feat: logs collector k8s deployment

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+CLUSTER := logs-cluster                    # k3d クラスター名
+REQUIRED_CTX := k3d-$(CLUSTER)              # 必要な kubectl コンテキスト名
+
+.PHONY: create delete apply teardown ctx diff guard-context print-vars
+
+create:                                     # k3d クラスター作成
+	k3d cluster create $(CLUSTER) --config k3d/cluster.yaml
+	kubectl config use-context $(REQUIRED_CTX)
+
+delete: guard-context                       # k3d クラスター削除
+	@echo "🗑  Deleting cluster $(CLUSTER)"
+	k3d cluster delete $(CLUSTER)
+
+apply: guard-context                        # マニフェスト適用
+	@echo "🚀 Applying to $(REQUIRED_CTX)"
+	kubectl --context $(REQUIRED_CTX) diff -k k8s/overlays/local || true
+	# 毎回マイグレーション実行したいので既存Jobを削除（なければ無視）
+	kubectl --context $(REQUIRED_CTX) -n logs-system delete job db-migrate --ignore-not-found
+	# マニフェスト適用（db/migrations含む）
+	kubectl --context $(REQUIRED_CTX) apply -k k8s/overlays/local
+	# 任意：DB起動とJob完了を待つ（失敗時ログ確認用）
+	kubectl --context $(REQUIRED_CTX) -n logs-system rollout status statefulset/db
+	kubectl --context $(REQUIRED_CTX) -n logs-system wait --for=condition=complete job/db-migrate --timeout=180s || (echo "❌ migration failed"; kubectl -n logs-system logs job/db-migrate; exit 1)
+
+teardown: guard-context                     # マニフェスト削除
+	@echo "🧹 Deleting manifests from $(REQUIRED_CTX)"
+	kubectl --context $(REQUIRED_CTX) delete -k k8s/overlays/local || true
+
+ctx:                                        # コンテキスト切替 & 確認
+	kubectl config use-context $(REQUIRED_CTX)
+	kubectl config get-contexts
+	kubectl --context $(REQUIRED_CTX) get nodes -o wide
+	kubectl --context $(REQUIRED_CTX) get ns
+
+diff: guard-context                         # マニフェスト差分表示
+	kubectl --context $(REQUIRED_CTX) diff -k k8s/overlays/local || true
+
+# ===== 安全確認：間違った context での実行防止 =====
+guard-context:
+	@CTX=$$(kubectl config current-context | tr -d '[:space:]'); \
+	REQ=$$(echo "$(REQUIRED_CTX)" | tr -d '[:space:]'); \
+	if [ "$$CTX" != "$$REQ" ]; then \
+		echo "❌ STOP: current-context=$$CTX. Please switch to $$REQ before running this command."; \
+		exit 1; \
+	else \
+		echo "✅ context=$$CTX OK"; \
+	fi
+
+print-vars:                                 # デバッグ用：変数値表示
+	@printf 'REQUIRED_CTX=[%s]\n' "$(REQUIRED_CTX)"
+	@printf 'CURRENT(kubectl)=[%s]\n' "$$(kubectl config current-context)"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,317 @@
 # logs-collector-infra
+
+ログ収集システムの Kubernetes インフラストラクチャ管理リポジトリです。k3d を使用したローカル開発環境と、Kustomize を使用したマニフェスト管理を提供します。
+
+## 目次
+
+- [アーキテクチャ](#アーキテクチャ)
+- [前提条件](#前提条件)
+- [クイックスタート](#クイックスタート)
+- [ディレクトリ構造](#ディレクトリ構造)
+- [使用方法](#使用方法)
+- [開発ガイド](#開発ガイド)
+- [トラブルシューティング](#トラブルシューティング)
+
+## アーキテクチャ
+
+このシステムは以下のコンポーネントで構成されています：
+
+| コンポーネント    | 説明                                     | バージョン  | ポート                  |
+| ----------------- | ---------------------------------------- | ----------- | ----------------------- |
+| **API Server**    | gRPC/REST API サーバー                   | v0.0.5      | gRPC: 50051, REST: 8080 |
+| **PostgreSQL**    | メタデータとログ情報の永続化             | 17          | 5432                    |
+| **Elasticsearch** | ログデータの検索・分析エンジン           | 8.18.1      | 9200                    |
+| **NATS**          | メッセージングシステム（JetStream 有効） | 2.10-alpine | 4222                    |
+
+## 前提条件
+
+以下のツールがインストールされている必要があります：
+
+- [k3d](https://k3d.io/) - ローカル Kubernetes クラスター
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) - Kubernetes CLI
+- [Docker](https://www.docker.com/) - コンテナランタイム
+
+## クイックスタート
+
+### 1. クラスターの作成
+
+```bash
+make create
+```
+
+### 2. アプリケーションのデプロイ
+
+```bash
+make apply
+```
+
+### 3. 動作確認
+
+```bash
+make ctx
+kubectl get pods -n logs-system
+```
+
+### 4. クリーンアップ
+
+```bash
+make teardown  # アプリケーション削除
+make delete    # クラスター削除
+```
+
+## ディレクトリ構造
+
+```
+logs-collector-infra/
+├── k3d/                           # k3d クラスター設定
+│   └── cluster.yaml               # クラスター構成定義
+├── k8s/                           # Kubernetes マニフェスト
+│   ├── base/                      # ベースマニフェスト
+│   │   ├── api/                   # API サーバー関連
+│   │   │   ├── deployment.yaml    # デプロイメント（v0.0.5）
+│   │   │   ├── kustomization.yaml # Kustomize 設定
+│   │   │   └── service.yaml       # サービス（gRPC:50051, REST:8080）
+│   │   ├── elasticsearch/         # Elasticsearch 関連
+│   │   │   ├── deployment.yaml    # デプロイメント（8.18.1）
+│   │   │   ├── kustomization.yaml # Kustomize 設定
+│   │   │   └── service.yaml       # サービス（HTTP:9200）
+│   │   ├── migrations/            # データベースマイグレーション
+│   │   │   ├── job.yaml           # マイグレーション実行Job
+│   │   │   ├── kustomization.yaml # Kustomize 設定
+│   │   │   └── sql-configmap.yaml # SQL設定マップ
+│   │   ├── nats/                  # NATS 関連
+│   │   │   ├── deployment.yaml    # デプロイメント（2.10-alpine）
+│   │   │   ├── kustomization.yaml # Kustomize 設定
+│   │   │   └── service.yaml       # サービス（JetStream:4222）
+│   │   ├── postgres/              # PostgreSQL 関連
+│   │   │   ├── kustomization.yaml # Kustomize 設定
+│   │   │   ├── service.yaml       # サービス（TCP:5432）
+│   │   │   └── statefulset.yaml   # StatefulSet（postgres:17）
+│   │   ├── kustomization.yaml     # ベース Kustomize 設定
+│   │   └── namespace.yaml         # ネームスペース定義
+│   └── overlays/                  # 環境別オーバーレイ
+│       └── local/                 # ローカル環境用
+│           └── kustomization.yaml # ローカル環境 Kustomize 設定
+├── Makefile                       # 開発用コマンド
+└── README.md                      # このファイル
+```
+
+````
+
+## 使用方法
+
+### Makefile コマンド
+
+| コマンド | 説明 | 詳細 |
+|---------|------|------|
+| `make create` | k3d クラスターを作成 | `k3d cluster create logs-cluster --config k3d/cluster.yaml` |
+| `make delete` | k3d クラスターを削除 | `k3d cluster delete logs-cluster` |
+| `make apply` | マニフェストを適用 | `kubectl apply -k k8s/overlays/local` |
+| `make teardown` | マニフェストを削除 | `kubectl delete -k k8s/overlays/local` |
+| `make ctx` | コンテキスト切替と確認 | `kubectl config use-context k3d-logs-cluster` |
+| `make diff` | マニフェストの差分表示 | `kubectl diff -k k8s/overlays/local` |
+
+### 手動コマンド
+
+```bash
+# クラスター作成
+k3d cluster create logs-cluster --config k3d/cluster.yaml
+
+# マニフェスト適用
+kubectl apply -k k8s/overlays/local
+
+# ログ確認
+kubectl logs -f deployment/logs-collector-api -n logs-system
+
+# サービス確認
+kubectl get svc -n logs-system
+````
+
+## 🔧 設定
+
+### k3d クラスター設定
+
+`k3d/cluster.yaml`でクラスター構成を定義：
+
+- マスターノード: 1 台
+- ワーカーノード: 2 台
+- ポートマッピング: 8080:80, 8443:443
+
+### アプリケーション設定
+
+各コンポーネントの設定は`k8s/base/`ディレクトリ内のマニフェストで管理：
+
+- **API Server**: `ghcr.io/keitashimura/logs-collector-api:v0.0.5`
+- **PostgreSQL**: `postgres:17`
+- **Elasticsearch**: `elasticsearch:8.18.1`
+- **NATS**: `nats:2.10-alpine`
+
+## 動作確認
+
+### ログ確認
+
+```bash
+# APIサーバーのログ
+kubectl logs -f deployment/logs-collector-api -n logs-system
+
+# PostgreSQLのログ
+kubectl logs -f statefulset/db -n logs-system
+
+# Elasticsearchのログ
+kubectl logs -f deployment/elasticsearch -n logs-system
+
+# NATSのログ
+kubectl logs -f deployment/nats -n logs-system
+```
+
+### ポートフォワードによるアクセス
+
+#### REST API
+
+```bash
+kubectl -n logs-system port-forward svc/logs-collector-api 8080:8080
+# 別ターミナルで
+curl -i http://localhost:8080/healthz
+```
+
+#### gRPC API
+
+```bash
+kubectl -n logs-system port-forward svc/logs-collector-api 50051:50051
+# grpcurlなどで疎通確認
+grpcurl -plaintext localhost:50051 list
+```
+
+#### Elasticsearch
+
+```bash
+kubectl -n logs-system port-forward svc/elasticsearch 19200:9200
+# 別ターミナルで
+curl -s localhost:19200/
+```
+
+正常に起動していれば、以下のようなクラスタ情報が返ってきます：
+
+```json
+{
+  "name": "elasticsearch-7b4c7d4b4d-xxxx",
+  "cluster_name": "docker-cluster",
+  "cluster_uuid": "FJp_8T1cR7y5i3l9Q8w9kA",
+  "version": {
+    "number": "8.18.1",
+    "build_flavor": "default",
+    "build_type": "docker",
+    "build_hash": "d2e1c8b5e0c6b7a2f4d7e7a1b6c7e1f3b7c6d8f1",
+    "build_date": "2024-05-27T10:25:39.123456789Z",
+    "build_snapshot": false,
+    "lucene_version": "9.9.2",
+    "minimum_wire_compatibility_version": "7.17.0",
+    "minimum_index_compatibility_version": "7.0.0"
+  },
+  "tagline": "You Know, for Search"
+}
+```
+
+## 🖥️ Apple Silicon (arm64) 対応
+
+Apple Silicon (M1/M2) 環境では、arm64 アーキテクチャでビルドし、k3d クラスターへインポートする必要があります。
+
+### ローカルでビルド（arm64）
+
+```bash
+docker build -t ghcr.io/keitashimura/logs-collector-api:v0.0.5 .
+k3d image import ghcr.io/keitashimura/logs-collector-api:v0.0.5 -c logs-cluster
+# pull させずに使えるようになる（imagePullPolicy: IfNotPresent 推奨）
+```
+
+AMD64 環境（GCP/AWS など）ではこの手順は不要です。
+
+## セキュリティ
+
+### 現在の設定
+
+- Elasticsearch: セキュリティ無効化（ローカル開発用）
+- PostgreSQL: テスト用認証情報
+- NATS: 認証なし（ローカル開発用）
+
+### 本番環境での注意点
+
+本番環境では以下の設定を推奨します：
+
+- 適切な認証・認可の設定
+- シークレット管理の実装
+- ネットワークポリシーの設定
+- リソース制限の設定
+
+## 開発ガイド
+
+### 新しいコンポーネントの追加
+
+1. `k8s/base/`に新しいディレクトリを作成
+2. 必要なマニフェストファイルを追加
+3. `k8s/base/kustomization.yaml`にリソースを追加
+4. 必要に応じて`k8s/overlays/local/`で環境固有の設定を追加
+
+### マニフェストの変更
+
+```bash
+# 差分確認
+make diff
+
+# 適用
+make apply
+```
+
+### デプロイ後の確認
+
+```bash
+# Pod の一覧を確認
+kubectl --context k3d-logs-cluster -n logs-system get pods
+
+# API サーバーのログをリアルタイムで確認
+kubectl --context k3d-logs-cluster -n logs-system logs -f deploy/logs-collector-api
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+#### 1. クラスターが起動しない
+
+```bash
+# クラスターの状態確認
+k3d cluster list
+```
+
+#### 2. Pod が起動しない
+
+```bash
+# Pod の詳細確認
+kubectl describe pod <pod-name> -n logs-system
+
+# イベント確認
+kubectl get events -n logs-system --sort-by='.lastTimestamp'
+```
+
+#### 3. ポートフォワードができない
+
+```bash
+# サービス確認
+kubectl get svc -n logs-system
+
+# エンドポイント確認
+kubectl get endpoints -n logs-system
+```
+
+### ログの確認方法
+
+```bash
+# 特定のPodのログ
+kubectl logs <pod-name> -n logs-system
+
+# リアルタイムログ
+kubectl logs -f <pod-name> -n logs-system
+
+# 前回のログ
+kubectl logs <pod-name> -n logs-system --previous
+```

--- a/k3d/cluster.yaml
+++ b/k3d/cluster.yaml
@@ -1,0 +1,24 @@
+apiVersion: k3d.io/v1alpha5 # k3d 設定のバージョン
+kind: Simple # クラスター構成の種類（シンプル構成）
+metadata:
+  name: logs-cluster # クラスター名
+
+servers: 1 # サーバーノード数（マスター）
+agents: 2 # エージェントノード数（ワーカー）
+
+# Ingress(LB)用ポートマッピング（Traefikなどが使用）
+ports:
+  - port: 8080:80 # ローカル8080 → クラスタ内80番（HTTP用Ingress）
+    nodeFilters:
+      - loadbalancer
+  - port: 8443:443 # ローカル8443 → クラスタ内443番（HTTPS用Ingress）
+    nodeFilters:
+      - loadbalancer
+
+  # NodePort サービスをホストに直接公開
+  - port: 30080:30080 # REST API(NodePort)用
+    nodeFilters:
+      - server:0
+  - port: 30051:30051 # gRPC API(NodePort)用
+    nodeFilters:
+      - server:0

--- a/k8s/base/api/deployment.yaml
+++ b/k8s/base/api/deployment.yaml
@@ -66,8 +66,8 @@ spec:
               drop: ["ALL"] # すべての特権を削除
           resources: # リソース要求/制限
             requests:
-              cpu: "100m"
-              memory: "128Mi"
+              cpu: "200m"
+              memory: "256Mi"
             limits:
               cpu: "500m"
               memory: "512Mi"

--- a/k8s/base/api/deployment.yaml
+++ b/k8s/base/api/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logs-collector-api # Deployment名
+  namespace: logs-system # Namespace
+spec:
+  replicas: 1
+  # ★ ローリングアップデート戦略を明示（無停止リリース）
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0 # 更新中も全Pod稼働を維持
+      maxSurge: 1 # 新Podを1つまで追加で起動可
+  selector:
+    matchLabels:
+      app: logs-collector-api # 対象Podのラベル
+  template:
+    metadata:
+      labels:
+        app: logs-collector-api # Podに付与するラベル
+    spec:
+      # Pod全体のセキュリティコンテキスト（コンテナ共通設定）
+      securityContext:
+        runAsNonRoot: true # rootでの実行を禁止
+        runAsUser: 1000 # 非rootユーザーID
+        fsGroup: 1000 # マウントボリュームのグループ所有権
+      containers:
+        - name: api
+          image: ghcr.io/keitashimura/logs-collector-api:v0.0.5
+          ports:
+            - containerPort: 50051 # gRPC
+            - containerPort: 8080 # REST
+          env: # DBやESの接続設定
+            - name: DB_HOST
+              value: db
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: logs_collector
+            - name: DB_USER
+              value: logs_collector_test
+            - name: DB_PASS
+              value: logs_collector_test
+            - name: ELASTICSEARCH_URL
+              value: http://elasticsearch:9200
+          # ★ プローブ（まずはTCPで最小構成）
+          readinessProbe: # 起動準備OKの判定
+            tcpSocket:
+              port: 8080 # RESTポートで確認
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe: # 稼働中チェック
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          # コンテナ単位のセキュリティ設定
+          securityContext:
+            allowPrivilegeEscalation: false # 権限昇格禁止
+            readOnlyRootFilesystem: true # ルートFSを読み取り専用に
+            capabilities:
+              drop: ["ALL"] # すべての特権を削除
+          resources: # リソース要求/制限
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/base/api/kustomization.yaml
+++ b/k8s/base/api/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/api/service.yaml
+++ b/k8s/base/api/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: logs-collector-api # Service名
+  namespace: logs-system # Namespace
+spec:
+  type: NodePort
+  selector:
+    app: logs-collector-api # 転送先Podのラベル
+  ports:
+    - name: http # REST用
+      port: 8080 # ClusterIP側のポート（K8s内部アクセス用）
+      targetPort: 8080 # Pod内コンテナのポート
+      nodePort: 30080 # ノード（ホスト）からアクセスするための固定ポート
+    - name: grpc # gRPC用
+      port: 50051
+      targetPort: 50051
+      nodePort: 30051

--- a/k8s/base/elasticsearch/deployment.yaml
+++ b/k8s/base/elasticsearch/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch # Deployment名
+  namespace: logs-system # Namespace
+spec:
+  replicas: 1 # Pod数
+  selector:
+    matchLabels:
+      app: elasticsearch # 対象Podのラベル
+  template:
+    metadata:
+      labels:
+        app: elasticsearch # Podに付与するラベル
+    spec:
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.18.1
+          env:
+            - name: discovery.type # 単一ノードモード
+              value: single-node
+            - name: xpack.security.enabled # セキュリティ無効化（ローカル用）
+              value: "false"
+          ports:
+            - containerPort: 9200 # Elasticsearch HTTPポート
+          readinessProbe: # 起動準備チェック
+            httpGet:
+              path: /
+              port: 9200
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe: # 動作チェック
+            httpGet:
+              path: /
+              port: 9200
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          volumeMounts:
+            - name: esdata
+              mountPath: /usr/share/elasticsearch/data
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+      volumes:
+        - name: esdata
+          emptyDir: {} # 永続化なし（開発用）

--- a/k8s/base/elasticsearch/kustomization.yaml
+++ b/k8s/base/elasticsearch/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/elasticsearch/service.yaml
+++ b/k8s/base/elasticsearch/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch # Service名
+  namespace: logs-system # Namespace
+spec:
+  selector:
+    app: elasticsearch # 対象Podのラベル
+  ports:
+    - name: http # HTTP用ポート
+      port: 9200 # Serviceが公開するポート
+      targetPort: 9200 # Pod内コンテナのポート

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - ./api
+  - ./elasticsearch
+  - ./nats
+  - ./postgres
+  - ./migrations

--- a/k8s/base/migrations/job.yaml
+++ b/k8s/base/migrations/job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-migrate # Job名（毎回apply時に実行するDBマイグレーション用）
+  namespace: logs-system
+spec:
+  backoffLimit: 3 # 失敗時の最大リトライ回数
+  template:
+    spec:
+      restartPolicy: OnFailure # コンテナ失敗時のみ再実行
+      containers:
+        - name: migrate
+          image: postgres:17 # マイグレーション実行用のPostgreSQL公式イメージ
+          env: # DB接続情報（Service名やユーザ/パスワード）
+            - name: PGHOST
+              value: db # PostgreSQL Service名
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: logs_collector_test
+            - name: PGPASSWORD
+              value: logs_collector_test
+            - name: PGDATABASE
+              value: logs_collector
+          volumeMounts: # SQLファイルをConfigMapとしてマウント
+            - name: sql
+              mountPath: /sql
+          command: # マイグレーション実行コマンド
+            - sh
+            - -c
+            - |
+              # PostgreSQLが起動して接続可能になるまで待機
+              until pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE"; do
+                echo "waiting for postgres..."; sleep 2;
+              done
+              # SQLファイルを適用（ON_ERROR_STOP=1でエラー時に停止）
+              psql -v ON_ERROR_STOP=1 -f /sql/init.sql
+      volumes:
+        - name: sql # マウントするConfigMap
+          configMap:
+            name: db-migration-sql # ConfigMap名
+            items:
+              - key: init.sql # ConfigMap内のキー
+                path: init.sql # コンテナ内でのファイル名

--- a/k8s/base/migrations/job.yaml
+++ b/k8s/base/migrations/job.yaml
@@ -25,6 +25,13 @@ spec:
           volumeMounts: # SQLファイルをConfigMapとしてマウント
             - name: sql
               mountPath: /sql
+          resources: # リソース要求・制限
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           command: # マイグレーション実行コマンド
             - sh
             - -c

--- a/k8s/base/migrations/kustomization.yaml
+++ b/k8s/base/migrations/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - sql-configmap.yaml
+  - job.yaml

--- a/k8s/base/migrations/sql-configmap.yaml
+++ b/k8s/base/migrations/sql-configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-migration-sql # DBマイグレーション用SQLを格納するConfigMap名
+  namespace: logs-system
+data:
+  init.sql: |
+    -- UUID生成用拡張（pgcrypto）を有効化
+    CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+    -- ログテーブル作成（存在しない場合のみ）
+    CREATE TABLE IF NOT EXISTS logs (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(), -- UUIDを自動生成
+      trace_id TEXT,                                 -- トレースID（分散トレーシング用）
+      timestamp TIMESTAMPTZ NOT NULL,                -- ログ発生時刻
+      level VARCHAR(10) NOT NULL,                    -- ログレベル（INFO, ERRORなど）
+      "service" TEXT NOT NULL,                       -- サービス名
+      message TEXT NOT NULL,                         -- ログメッセージ
+      metadata JSONB,                                -- 追加メタデータ（任意のJSON）
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()  -- 作成時刻（デフォルト現在時刻）
+    );
+
+    -- インデックス作成（存在しない場合のみ）
+    CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON logs (timestamp);
+    CREATE INDEX IF NOT EXISTS idx_logs_service   ON logs ("service");
+    CREATE INDEX IF NOT EXISTS idx_logs_level     ON logs (level);

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,5 @@
+# k8s/base/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logs-system

--- a/k8s/base/nats/deployment.yaml
+++ b/k8s/base/nats/deployment.yaml
@@ -19,3 +19,10 @@ spec:
           args: ["-js"] # JetStream有効化
           ports:
             - containerPort: 4222 # クライアント接続用ポート
+          resources: # リソース要求/制限
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/base/nats/deployment.yaml
+++ b/k8s/base/nats/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats # Deployment名
+  namespace: logs-system # Namespace
+spec:
+  replicas: 1 # Pod数
+  selector:
+    matchLabels:
+      app: nats # 対象Podのラベル
+  template:
+    metadata:
+      labels:
+        app: nats # Podに付与するラベル
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine # Composeと同じバージョン
+          args: ["-js"] # JetStream有効化
+          ports:
+            - containerPort: 4222 # クライアント接続用ポート

--- a/k8s/base/nats/kustomization.yaml
+++ b/k8s/base/nats/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/nats/service.yaml
+++ b/k8s/base/nats/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats # Service名
+  namespace: logs-system # Namespace
+spec:
+  selector:
+    app: nats # 対象Podのラベル
+  type: NodePort # ホストから直接アクセス可能に
+  ports:
+    - name: client
+      port: 4222 # Service側ポート
+      targetPort: 4222 # Pod内ポート
+      nodePort: 30022 # ホスト側ポート

--- a/k8s/base/postgres/kustomization.yaml
+++ b/k8s/base/postgres/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - statefulset.yaml
+  - service.yaml

--- a/k8s/base/postgres/service.yaml
+++ b/k8s/base/postgres/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db # Service名（アプリからのDB_HOST）
+  namespace: logs-system
+spec:
+  selector:
+    app: db # 対象Podのラベル
+  ports:
+    - name: pg # PostgreSQL用ポート
+      port: 5432 # Serviceのポート
+      targetPort: 5432 # Pod内ポート

--- a/k8s/base/postgres/statefulset.yaml
+++ b/k8s/base/postgres/statefulset.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db # StatefulSet名
+  namespace: logs-system
+spec:
+  serviceName: db # 紐づけるService名
+  replicas: 1 # Pod数
+  selector:
+    matchLabels:
+      app: db # 対象Podのラベル
+  template:
+    metadata:
+      labels:
+        app: db # Podに付与するラベル
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17 # Postgresバージョン
+          ports:
+            - containerPort: 5432 # PostgreSQL用ポート
+          env:
+            - name: POSTGRES_DB
+              value: "logs_collector"
+            - name: POSTGRES_USER
+              value: "logs_collector_test"
+            - name: POSTGRES_PASSWORD
+              value: "logs_collector_test"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi # 永続ボリュームサイズ

--- a/k8s/overlays/local/kustomization.yaml
+++ b/k8s/overlays/local/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1 # Kustomizeの設定バージョン
+kind: Kustomization # Kustomizeの定義ファイル
+
+resources:
+  - ../../base # baseディレクトリの構成を読み込む


### PR DESCRIPTION
## 概要

logs-collector プロジェクトの Kubernetes デプロイメント設定を追加し、ローカル開発環境での運用を可能にしました。

## 主な変更内容

- **Kubernetes マニフェストの追加**: API、Elasticsearch、NATS、PostgreSQL のデプロイメント設定
- **Kustomize 設定**: ベース設定とローカル環境用のオーバーレイ構成
- **データベースマイグレーション**: SQL スクリプトと Job 設定
- **リソース制限**: 各デプロイメントに適切なリソース制限を設定
- **Makefile**: k8s 操作のための便利なコマンドを追加
- **k3d 設定**: ローカル Kubernetes クラスターの設定
- **CI/CD 設定**: GitHub Actions によるリリース自動化ワークフロー

## 技術スタック

- Kubernetes
- Kustomize
- k3d (ローカル開発用)
- PostgreSQL (StatefulSet)
- NATS
- Elasticsearch
- GitHub Actions

## CI/CD 機能

- **自動リリース**: バージョンタグ（v\*）プッシュ時に GitHub リリースを自動作成
- **リリースノート生成**: コミット履歴から自動的にリリースノートを生成

## ステージングされていないファイルの対応状況

### 未対応の理由

- **CI/CD 設定の検証待ち**: GitHub Actions のワークフローが実際に動作するかテスト中
- **kube-linter 設定の調整中**: 開発環境に適したルール設定の微調整が必要
- **最終的な品質確認**: マニフェストの動作確認後に CI/CD 設定を追加予定
