### PR TITLE
fix: correct release workflow location

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false


### PR DESCRIPTION
## 概要

GitHub Actions のリリースワークフローを正しいディレクトリ構造に移動しました。

## 変更内容

- `.github/release.yaml` → `.github/workflows/release.yaml` に移動
